### PR TITLE
Enhancement: Add rule for Makefile to .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -75,6 +75,10 @@ indent_size = 2
 indent_style = tab
 indent_size = 4
 
+[Makefile]
+indent_style = tab
+indent_size = 4
+
 [package.json]
 indent_style = space
 indent_size = 2


### PR DESCRIPTION
This PR

* [x] adds a rule for `Makefile` files to `.editorconfig`

Follows #5.