### PR TITLE
Enhancement: Add migration target to Makefile for creating a Doctrine migration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,6 +120,11 @@ fixtures: ##@development run 'bin/console hautelook:fixtures:load' in container
 	$(CLI) bin/console hautelook:fixtures:load
 .PHONY: fixtures
 
+migration: ##@development Validate the schema and create a Doctrine migration when necessary.
+	$(CLI) bin/console doctrine:schema:validate --skip-sync
+	$(CLI) bin/console doctrine:migrations:diff
+.PHONY: migration
+
 php-cs-fixer: ##@development run 'vendor/bin/php-cs-fixer fix' in container
 	$(CLI) vendor/bin/php-cs-fixer fix --diff --verbose
 .PHONY: php-cs-fixer


### PR DESCRIPTION
This PR

* [x] adds a ` migration` target to `Makefile` 

💁‍♂ Run

```
$ make migration
```

to validate the Doctrine mapping on your entities and, when successful and necessary, generate a migration.