### PR TITLE
Fix: Remove non-applicable autoload configuration

### DIFF
--- a/api/composer.json
+++ b/api/composer.json
@@ -35,11 +35,6 @@
             "App\\": "src/"
         }
     },
-    "autoload-dev": {
-        "psr-4": {
-            "App\\Tests\\": "tests/"
-        }
-    },
     "replace": {
         "paragonie/random_compat": "2.*",
         "symfony/polyfill-ctype": "*",


### PR DESCRIPTION
This PR

* [x] non-applicable autoload configuration from `composer.json`