### PR TITLE
Fix: Flip arguments

### DIFF
--- a/api/src/Faker/Provider/AdorableAvatarUrlProvider.php
+++ b/api/src/Faker/Provider/AdorableAvatarUrlProvider.php
@@ -15,8 +15,8 @@ final class AdorableAvatarUrlProvider extends Provider\Base
     {
         return sprintf(
             'https://api.adorable.io/avatars/%d/%s.png',
-            $userName,
-            $size
+            $size,
+            $userName
         );
     }
 }


### PR DESCRIPTION
This PR

* [x] flips arguments when assembling avatar URLs