### PR TITLE
Fix: Configure default locale used by Faker\Generator

### DIFF
--- a/api/config/services.yaml
+++ b/api/config/services.yaml
@@ -28,3 +28,11 @@ services:
 
     App\Faker\Provider\AdorableAvatarUrlProvider: ~
     App\Faker\Provider\DateTimeImmutableProvider: ~
+
+    nelmio_alice.faker.generator:
+        class: Faker\Generator
+        factory:
+            - Faker\Factory
+            - create
+        arguments:
+            - 'de_DE'


### PR DESCRIPTION
This PR

* [x] configures the default locale used by `Faker\Generator` 