### PR TITLE
Fix: Add configuration otherwise missing for prod environment

### DIFF
--- a/api/config/packages/prod/hautelook_alice.yaml
+++ b/api/config/packages/prod/hautelook_alice.yaml
@@ -1,0 +1,2 @@
+imports:
+    - { resource: ../dev/hautelook_alice.yaml }


### PR DESCRIPTION
This PR

* [x] adds a configuration which would otherwise be missing for the `prod` environment