### PR TITLE
Fix: Enable HautelookAliceBundle for all environments

### DIFF
--- a/api/config/bundles.php
+++ b/api/config/bundles.php
@@ -13,5 +13,5 @@ return [
     Doctrine\Bundle\MigrationsBundle\DoctrineMigrationsBundle::class => ['all' => true],
     Nelmio\Alice\Bridge\Symfony\NelmioAliceBundle::class => ['dev' => true, 'test' => true],
     Fidry\AliceDataFixtures\Bridge\Symfony\FidryAliceDataFixturesBundle::class => ['dev' => true, 'test' => true],
-    Hautelook\AliceBundle\HautelookAliceBundle::class => ['dev' => true, 'test' => true],
+    Hautelook\AliceBundle\HautelookAliceBundle::class => ['all' => true],
 ];


### PR DESCRIPTION
This PR

* [x] enables the `HautelookAliceBundle` for all environments