### PR TITLE
Fix: Enable FidryAliceDataFixturesBundle for all environments

### DIFF
--- a/api/config/bundles.php
+++ b/api/config/bundles.php
@@ -12,6 +12,6 @@ return [
     Symfony\Bundle\WebProfilerBundle\WebProfilerBundle::class => ['dev' => true, 'test' => true],
     Doctrine\Bundle\MigrationsBundle\DoctrineMigrationsBundle::class => ['all' => true],
     Nelmio\Alice\Bridge\Symfony\NelmioAliceBundle::class => ['dev' => true, 'test' => true],
-    Fidry\AliceDataFixtures\Bridge\Symfony\FidryAliceDataFixturesBundle::class => ['dev' => true, 'test' => true],
+    Fidry\AliceDataFixtures\Bridge\Symfony\FidryAliceDataFixturesBundle::class => ['all' => true],
     Hautelook\AliceBundle\HautelookAliceBundle::class => ['all' => true],
 ];


### PR DESCRIPTION
This PR

* [x] enables the `FidryAliceDataFixturesBundle` for all environments

Follows #56.