### PR TITLE
Fix: Purge tables before loading fixture data during deployment

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-release: cd api && bin/console doctrine:migrations:status && bin/console doctrine:migrations:migrate --no-interaction && bin/console hautelook:fixtures:load --append
+release: cd api && bin/console doctrine:migrations:status && bin/console doctrine:migrations:migrate --no-interaction && bin/console hautelook:fixtures:load --no-interaction
 web: cd api && vendor/bin/heroku-php-apache2 public/


### PR DESCRIPTION
This PR

* [x] purges tables before loading fixture data during deployment